### PR TITLE
Exit build.sh early if $ANDROID_SDK_ROOT or $ANDROID_NDK_ROOT are not set.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,8 +32,17 @@ uniffi-bindgen generate src/bdk.udl --no-format --out-dir ../jvm/src/main/kotlin
 
 ## android
 
-# If ANDROID_NDK_ROOT is not set then set it to github actions default
-[ -z "$ANDROID_NDK_ROOT" ] && export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk-bundle
+# Android SDK is required.
+if [ ! -d "$ANDROID_SDK_ROOT" ]; then
+  echo "Error: \$ANDROID_SDK_ROOT is not set."
+  exit 1
+fi
+
+# Android NDK is required.
+if [ ! -d "$ANDROID_NDK_ROOT" ]; then
+  echo "Error: \$ANDROID_NDK_ROOT is not set."
+  exit 1
+fi
 
 # Update this line accordingly if you are not building *from* darwin-x86_64 or linux-x86_64
 export PATH=$PATH:$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/`uname | tr '[:upper:]' '[:lower:]'`-x86_64/bin


### PR DESCRIPTION
### Description

If $ANDROID_SDK_ROOT or $ANDROID_NDK_ROOT env vars are not set, exit the build script early.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
